### PR TITLE
Fix: Prevent footer jump on initial page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,13 @@
       body {
         opacity: 0;
         visibility: hidden;
-        height: 100%;
-        position: fixed;
+        /* height: 100%; Removed to allow natural body height */
+        /* position: fixed; Removed to prevent jump */
         width: 100%;
-        top: 0;
-        left: 0;
+        /* top: 0; Not needed without position:fixed */
+        /* left: 0; Not needed without position:fixed */
+        margin: 0; /* Ensure no default body margin interferes */
+        min-height: 100%; /* Ensure body takes at least viewport height if content is short */
       }
       /* Loading state */
       body.loading {
@@ -33,7 +35,7 @@
       body.loaded {
         opacity: 1;
         visibility: visible;
-        position: relative;
+        position: relative; /* Keep this for potential absolute positioning of children */
         transition: opacity 0.3s ease-out;
       }
     </style>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,9 +8,6 @@ function handlePageLoad(): void {
   // Force scroll to top immediately
   window.scrollTo(0, 0);
 
-  // Ensure the body starts at the top
-  document.body.style.top = '0';
-
   // Remove loading class and add loaded class on the next frame
   requestAnimationFrame(() => {
     document.body.classList.remove('loading');


### PR DESCRIPTION
- Modified `index.html` to remove `position: fixed` from the initial body styles. This prevents the body from being constrained to viewport height during early rendering, which was causing the footer to appear at the bottom of the viewport and then jump when the body's position was later changed to relative.
- Removed a redundant `document.body.style.top = '0';` call in `src/main.tsx` as it was no longer necessary after the `index.html` changes.